### PR TITLE
Fix async update for deleted user tickets

### DIFF
--- a/backend/src/helpers/UpdateDeletedUserOpenTicketsStatus.ts
+++ b/backend/src/helpers/UpdateDeletedUserOpenTicketsStatus.ts
@@ -7,30 +7,32 @@ const UpdateDeletedUserOpenTicketsStatus = async (
   tenantId: string | number,
   userIdRequest: string | number
 ): Promise<void> => {
-  tickets.forEach(async t => {
-    const ticketId = t.id.toString();
+  await Promise.all(
+    tickets.map(async t => {
+      const ticketId = t.id.toString();
 
-    await UpdateTicketService({
-      ticketData: { status: "pending", tenantId },
-      ticketId,
-      userIdRequest
-    });
+      await UpdateTicketService({
+        ticketData: { status: "pending", tenantId },
+        ticketId,
+        userIdRequest
+      });
 
-    // const io = getIO();
-    // if (ticket.status !== oldStatus) {
-    //   io.to(`${tenantId}-${oldStatus}`).emit(`${tenantId}-ticket`, {
-    //     action: "delete",
-    //     ticketId: ticket.id
-    //   });
-    // }
+      // const io = getIO();
+      // if (ticket.status !== oldStatus) {
+      //   io.to(`${tenantId}-${oldStatus}`).emit(`${tenantId}-ticket`, {
+      //     action: "delete",
+      //     ticketId: ticket.id
+      //   });
+      // }
 
-    // io.to(`${tenantId}-${ticket.status}`)
-    //   .to(`${tenantId}-${ticketId}`)
-    //   .emit(`${tenantId}-ticket`, {
-    //     action: "updateStatus",
-    //     ticket
-    //   });
-  });
+      // io.to(`${tenantId}-${ticket.status}`)
+      //   .to(`${tenantId}-${ticketId}`)
+      //   .emit(`${tenantId}-ticket`, {
+      //     action: "updateStatus",
+      //     ticket
+      //   });
+    })
+  );
 };
 
 export default UpdateDeletedUserOpenTicketsStatus;

--- a/backend/src/services/UserServices/DeleteUserService.ts
+++ b/backend/src/services/UserServices/DeleteUserService.ts
@@ -21,7 +21,7 @@ const DeleteUserService = async (
   });
 
   if (userOpenTickets.length > 0) {
-    UpdateDeletedUserOpenTicketsStatus(
+    await UpdateDeletedUserOpenTicketsStatus(
       userOpenTickets,
       tenantId,
       userIdRequest


### PR DESCRIPTION
## Summary
- fix UpdateDeletedUserOpenTicketsStatus to wait for all async operations
- await status updates when deleting a user

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484677bb28832e90b79753a8ff0c14